### PR TITLE
Storing Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "1.11.0",
     "@verdaccio/babel-preset": "0.2.1",
     "@verdaccio/eslint-config": "0.0.1",
-    "@verdaccio/types": "5.2.2",
+    "@verdaccio/types": "6.2.0",
     "codecov": "3.5.0",
     "cross-env": "5.2.0",
     "eslint": "5.15.3",

--- a/src/local-database.ts
+++ b/src/local-database.ts
@@ -8,7 +8,7 @@ import mkdirp from 'mkdirp';
 import LocalDriver, { noSuchFile } from './local-fs';
 import { loadPrivatePackages } from './pkg-utils';
 
-import { IPackageStorage, IPluginStorage, StorageList, LocalStorage, Logger, Config, Callback } from '@verdaccio/types';
+import { IPackageStorage, IPluginStorage, StorageList, LocalStorage, Logger, Config, Callback, Token, TokenFilter } from '@verdaccio/types';
 import { getInternalError } from "@verdaccio/commons-api/lib";
 
 const DEPRECATED_DB_NAME = '.sinopia-db.json';
@@ -156,6 +156,18 @@ class LocalDatabase implements IPluginStorage<{}> {
       },
       onEnd
     );
+  }
+
+  public saveToken(token: Token): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  public deleteToken(user: string, tokenKey: string): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  public readTokens(filter: TokenFilter): Promise<Token[]> {
+    throw new Error("Method not implemented.");
   }
 
   private _getTime(time: number, mtime: Date) {


### PR DESCRIPTION
**Type:**

Implement token storage.
It has to store mainly tokens object with the key, that (for now) is the MD5 of the JWT token generated.

**Description:**

I was trying leveldb as shared with @juanpicado , but I'm asking if it is worth because it would need an additional step of installing it, so verdaccio would no more just "install and play".
Additionally, [there is no "select where" query](https://github.com/google/leveldb/blob/master/doc/index.md) in order to get all the tokens created by a user - unless to store twice times the tokens:

- one per user (key: userId - token array)
- one per MD5 (key: MD5(JWT) - token)

Should check for other possibilities or is this ok?

Relates to https://github.com/verdaccio/verdaccio/pull/1271
