### PR TITLE
feat: add logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage:publish": "codecov"
   },
   "dependencies": {
-    "@verdaccio/commons-api": "0.1.0",
+    "@verdaccio/commons-api": "0.1.1",
     "@verdaccio/file-locking": "1.0.3",
     "@verdaccio/streams": "2.0.0",
     "async": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "release": "standard-version -a -s",
     "test": "jest",
-    "lint": "eslint . --ext .js,.ts",
+    "lint": "npm run type-check && eslint . --ext .js,.ts",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
@@ -18,25 +18,24 @@
     "coverage:publish": "codecov"
   },
   "dependencies": {
+    "@verdaccio/commons-api": "0.1.0",
     "@verdaccio/file-locking": "1.0.3",
     "@verdaccio/streams": "2.0.0",
     "async": "3.1.0",
-    "http-errors": "1.7.3",
     "lodash": "4.17.11",
     "mkdirp": "0.5.1"
   },
   "devDependencies": {
     "@commitlint/cli": "8.0.0",
     "@commitlint/config-conventional": "8.0.0",
-    "@types/http-errors": "1.6.1",
     "@types/jest": "24.0.15",
-    "@types/lodash": "^4.14.135",
-    "@types/minimatch": "^3.0.3",
-    "@types/node": "12.0.10",
+    "@types/lodash": "4.14.135",
+    "@types/minimatch": "3.0.3",
+    "@types/node": "12.0.12",
     "@typescript-eslint/eslint-plugin": "1.11.0",
     "@verdaccio/babel-preset": "0.2.1",
     "@verdaccio/eslint-config": "0.0.1",
-    "@verdaccio/types": "5.0.0-beta.4",
+    "@verdaccio/types": "5.2.2",
     "codecov": "3.5.0",
     "cross-env": "5.2.0",
     "eslint": "5.15.3",
@@ -46,9 +45,6 @@
     "rmdir-sync": "1.0.1",
     "standard-version": "6.0.1",
     "typescript": "3.5.2"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   },
   "keywords": [
     "plugin",

--- a/src/local-database.ts
+++ b/src/local-database.ts
@@ -17,17 +17,17 @@ const DB_NAME = '.verdaccio-db.json';
  * Handle local database.
  */
 class LocalDatabase implements IPluginStorage<{}> {
-  path: string;
-  logger: Logger;
-  data: LocalStorage;
-  config: Config;
-  locked: boolean;
+  public path: string;
+  public logger: Logger;
+  public data: LocalStorage;
+  public config: Config;
+  public locked: boolean;
 
   /**
    * Load an parse the local json database.
    * @param {*} path the database path
    */
-  constructor(config: Config, logger: Logger) {
+  public constructor(config: Config, logger: Logger) {
     this.config = config;
     this.path = this._buildStoragePath(config);
     this.logger = logger;
@@ -36,13 +36,14 @@ class LocalDatabase implements IPluginStorage<{}> {
     this._sync();
   }
 
-  getSecret(): Promise<any> {
+  getSecret(): Promise<string> {
     return Promise.resolve(this.data.secret);
   }
 
-  setSecret(secret: string): Promise<any> {
-    return new Promise((resolve, reject) => {
+  setSecret(secret: string): Promise<string> {
+    return new Promise(resolve => {
       this.data.secret = secret;
+
       resolve(this._sync());
     });
   }
@@ -52,7 +53,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * @param {*} name
    * @return {Error|*}
    */
-  add(name: string, cb: Callback) {
+  public add(name: string, cb: Callback) {
     if (this.data.list.indexOf(name) === -1) {
       this.data.list.push(name);
       cb(this._sync());
@@ -61,7 +62,7 @@ class LocalDatabase implements IPluginStorage<{}> {
     }
   }
 
-  search(onPackage: Callback, onEnd: Callback, validateName: any): void {
+  public search(onPackage: Callback, onEnd: Callback, validateName: any): void {
     const storages = this._getCustomPackageLocalStorages();
     this.logger.trace(`local-storage: [search]: ${JSON.stringify(storages)}`);
     const base = Path.dirname(this.config.self_path);
@@ -151,11 +152,11 @@ class LocalDatabase implements IPluginStorage<{}> {
     );
   }
 
-  _getTime(time: number, mtime: Date) {
+  private _getTime(time: number, mtime: Date) {
     return time ? time : mtime;
   }
 
-  _getCustomPackageLocalStorages() {
+  private _getCustomPackageLocalStorages() {
     const storages = {};
 
     // add custom storage if exist
@@ -184,7 +185,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * @param {*} name
    * @return {Error|*}
    */
-  remove(name: string, cb: Callback) {
+  public remove(name: string, cb: Callback) {
     this.get((err, data) => {
       if (err) {
         cb(new Error('error on get'));
@@ -203,7 +204,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * Return all database elements.
    * @return {Array}
    */
-  get(cb: Callback) {
+  public get(cb: Callback) {
     cb(null, this.data.list);
   }
 
@@ -211,7 +212,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * Syncronize {create} database whether does not exist.
    * @return {Error|*}
    */
-  _sync() {
+  private _sync() {
     if (this.locked) {
       this.logger.error('Database is locked, please check error message printed during startup to prevent data loss.');
       return new Error('Verdaccio database is locked, please contact your administrator to checkout logs during verdaccio startup.');
@@ -232,7 +233,7 @@ class LocalDatabase implements IPluginStorage<{}> {
     }
   }
 
-  getPackageStorage(packageName: string): IPackageStorage {
+  public getPackageStorage(packageName: string): IPackageStorage {
     const packageAccess = this.config.getMatchedPackagesSpec(packageName);
 
     const packagePath: string = this._getLocalStoragePath(packageAccess ? packageAccess.storage : undefined);
@@ -253,7 +254,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * @return {String}
    * @private
    */
-  _getLocalStoragePath(storage: string | void): string {
+  private _getLocalStoragePath(storage: string | void): string {
     const globalConfigStorage = this.config ? this.config.storage : undefined;
     if (_.isNil(globalConfigStorage)) {
       throw new Error('global storage is required for this plugin');
@@ -272,7 +273,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * @return {string|String|*}
    * @private
    */
-  _buildStoragePath(config: Config) {
+  private _buildStoragePath(config: Config) {
     const dbGenPath = function(dbName: string) {
       return Path.join(Path.resolve(Path.dirname(config.self_path || ''), config.storage as string, dbName));
     };
@@ -290,7 +291,7 @@ class LocalDatabase implements IPluginStorage<{}> {
    * @private
    * @return {Object}
    */
-  _fetchLocalPackages(): LocalStorage {
+  private _fetchLocalPackages(): LocalStorage {
     const list: StorageList = [];
     const emptyDatabase = { list, secret: '' };
 

--- a/src/local-fs.ts
+++ b/src/local-fs.ts
@@ -54,8 +54,8 @@ const renameTmp = function(src, dst, _cb) {
 export type ILocalFSPackageManager = ILocalPackageManager & { path: string };
 
 export default class LocalFS implements ILocalFSPackageManager {
-  path: string;
-  logger: Logger;
+  public path: string;
+  public logger: Logger;
 
   constructor(path: string, logger: Logger) {
     this.path = path;
@@ -77,26 +77,44 @@ export default class LocalFS implements ILocalFSPackageManager {
     * @param {*} transformPackage
     * @param {*} onEnd
     */
-  updatePackage(name: string, updateHandler: Callback, onWrite: Callback, transformPackage: Function, onEnd: Callback) {
+  public updatePackage(name: string, updateHandler: Callback, onWrite: Callback, transformPackage: Function, onEnd: Callback) {
     this._lockAndReadJSON(pkgFileName, (err, json) => {
       let locked = false;
       const self = this;
       // callback that cleans up lock first
-      const unLockCallback = function(lockError: Error) {
+      const unLockCallback = (lockError: Error) => {
         const _args = arguments;
 
         if (locked) {
-          self._unlockJSON(pkgFileName, function() {
+          self._unlockJSON(pkgFileName, () => {
             // ignore any error from the unlock
+            if (lockError !== null) {
+              this.logger.trace(
+                {
+                  name,
+                  lockError
+                },
+                '[local-storage/updatePackage/unLockCallback] file: @{name} lock has failed lockError: @{lockError}'
+              );
+            }
+
             onEnd.apply(lockError, _args);
           });
         } else {
+          this.logger.trace({ name }, '[local-storage/updatePackage/unLockCallback] file: @{name} has been updated');
+
           onEnd(..._args);
         }
       };
 
       if (!err) {
         locked = true;
+        this.logger.trace(
+          {
+            name
+          },
+          '[local-storage/updatePackage] file: @{name} has been locked'
+        );
       }
 
       if (_.isNil(err) === false) {
@@ -113,46 +131,62 @@ export default class LocalFS implements ILocalFSPackageManager {
         if (err) {
           return unLockCallback(err);
         }
+
         onWrite(name, transformPackage(json), unLockCallback);
       });
     });
   }
 
-  deletePackage(fileName: string, callback: (err: NodeJS.ErrnoException | null) => void) {
-    return fs.unlink(this._getStorage(fileName), callback);
+  public deletePackage(packageName: string, callback: (err: NodeJS.ErrnoException | null) => void) {
+    this.logger.debug({ packageName }, '[local-storage/deletePackage] delete a package @{packageName}');
+
+    return fs.unlink(this._getStorage(packageName), callback);
   }
 
-  removePackage(callback: (err: NodeJS.ErrnoException | null) => void): void {
+  public removePackage(callback: (err: NodeJS.ErrnoException | null) => void): void {
+    this.logger.debug({ packageName: this.path }, '[local-storage/removePackage] remove a package: @{packageName}');
+
     fs.rmdir(this._getStorage('.'), callback);
   }
 
-  createPackage(name: string, value: Package, cb: Function) {
+  public createPackage(name: string, value: Package, cb: Callback) {
+    this.logger.debug({ packageName: name }, '[local-storage/createPackage] create a package: @{packageName}');
+
     this._createFile(this._getStorage(pkgFileName), this._convertToString(value), cb);
   }
 
-  savePackage(name: string, value: Package, cb: Function) {
+  public savePackage(name: string, value: Package, cb: Callback) {
+    this.logger.debug({ packageName: name }, '[local-storage/savePackage] save a package: @{packageName}');
+
     this._writeFile(this._getStorage(pkgFileName), this._convertToString(value), cb);
   }
 
-  readPackage(name: string, cb: Function) {
+  public readPackage(name: string, cb: Callback) {
+    this.logger.debug({ packageName: name }, '[local-storage/readPackage] read a package: @{packageName}');
+
     this._readStorageFile(this._getStorage(pkgFileName)).then(
-      function(res) {
+      res => {
         try {
           const data: any = JSON.parse(res.toString('utf8'));
 
+          this.logger.trace({ packageName: name }, '[local-storage/readPackage/_readStorageFile] read a package succeed: @{packageName}');
           cb(null, data);
         } catch (err) {
+          this.logger.trace({ err }, '[local-storage/readPackage/_readStorageFile] error on read a package: @{err}');
           cb(err);
         }
       },
-      function(err) {
+      err => {
+        this.logger.trace({ err }, '[local-storage/readPackage/_readStorageFile] error on read a package: @{err}');
+
         return cb(err);
       }
     );
   }
 
-  writeTarball(name: string): IUploadTarball {
+  public writeTarball(name: string): IUploadTarball {
     const uploadStream = new UploadTarball({});
+    this.logger.debug({ packageName: name }, '[local-storage/writeTarball] write a tarball for package: @{packageName}');
 
     let _ended = 0;
     uploadStream.on('end', function() {
@@ -219,8 +253,10 @@ export default class LocalFS implements ILocalFSPackageManager {
     return uploadStream;
   }
 
-  readTarball(name: string) {
+  public readTarball(name: string) {
     const pathName: string = this._getStorage(name);
+    this.logger.debug({ packageName: name }, '[local-storage/readTarball] read a tarball for package: @{packageName}');
+
     const readTarballStream = new ReadTarball({});
 
     const readStream = fs.createReadStream(pathName);
@@ -247,45 +283,59 @@ export default class LocalFS implements ILocalFSPackageManager {
     return readTarballStream;
   }
 
-  _createFile(name: string, contents: any, callback: Function) {
+  private _createFile(name: string, contents: any, callback: Function) {
+    this.logger.trace({ name }, '[local-storage/_createFile] create a new file: @{name}');
+
     fs.exists(name, exists => {
       if (exists) {
+        this.logger.trace({ name }, '[local-storage/_createFile] file cannot be created, it already exists: @{name}');
+
         return callback(fSError(fileExist));
       }
+
       this._writeFile(name, contents, callback);
     });
   }
 
-  _readStorageFile(name: string): Promise<any> {
+  private _readStorageFile(name: string): Promise<any> {
     return new Promise((resolve, reject) => {
+      this.logger.trace({ name }, '[local-storage/_readStorageFile] read a file: @{name}');
+
       fs.readFile(name, (err, data) => {
         if (err) {
+          this.logger.trace({ err }, '[local-storage/_readStorageFile] error on read the file: @{name}');
           reject(err);
         } else {
+          this.logger.trace({ name }, '[local-storage/_readStorageFile] read file succeed: @{name}');
+
           resolve(data);
         }
       });
     });
   }
 
-  _convertToString(value: Package): string {
+  private _convertToString(value: Package): string {
     return JSON.stringify(value, null, '\t');
   }
 
-  _getStorage(fileName: string = '') {
+  private _getStorage(fileName: string = '') {
     const storagePath: string = path.join(this.path, fileName);
 
     return storagePath;
   }
 
-  _writeFile(dest: string, data: string, cb: Function) {
+  private _writeFile(dest: string, data: string, cb: Callback) {
     const createTempFile = cb => {
       const tempFilePath = tempFile(dest);
 
       fs.writeFile(tempFilePath, data, err => {
         if (err) {
+          this.logger.trace({ name: dest }, '[local-storage/_writeFile] new file: @{name} has been created');
+
           return cb(err);
         }
+
+        this.logger.trace({ name: dest }, '[local-storage/_writeFile] creating a new file: @{name}');
         renameTmp(tempFilePath, dest, cb);
       });
     };
@@ -304,7 +354,7 @@ export default class LocalFS implements ILocalFSPackageManager {
     });
   }
 
-  _lockAndReadJSON(name: string, cb: Function) {
+  private _lockAndReadJSON(name: string, cb: Function) {
     const fileName: string = this._getStorage(name);
 
     readFile(
@@ -313,16 +363,20 @@ export default class LocalFS implements ILocalFSPackageManager {
         lock: true,
         parse: true
       },
-      function(err, res) {
+      (err, res) => {
         if (err) {
+          this.logger.trace({ name }, '[local-storage/_lockAndReadJSON] read new file: @{name} has failed');
+
           return cb(err);
         }
+
+        this.logger.trace({ name }, '[local-storage/_lockAndReadJSON] file: @{name} read');
         return cb(null, res);
       }
     );
   }
 
-  _unlockJSON(name: string, cb: Function) {
+  private _unlockJSON(name: string, cb: Function) {
     unlockFile(this._getStorage(name), cb);
   }
 }

--- a/tests/local-fs.test.ts
+++ b/tests/local-fs.test.ts
@@ -2,21 +2,22 @@ import path from 'path';
 import mkdirp from 'mkdirp';
 import fs from 'fs';
 import rm from 'rmdir-sync';
-import { Logger, ILocalPackageManager } from '@verdaccio/types';
+
 import LocalDriver, { fileExist, fSError, noSuchFile, resourceNotAvailable } from '../src/local-fs';
+import { Logger, ILocalPackageManager } from '@verdaccio/types';
 import pkg from './__fixtures__/pkg';
 
 let localTempStorage: string;
 const pkgFileName = 'package.json';
 
 const logger: Logger = {
-  error: e => console.warn(e),
-  info: e => console.warn(e),
-  debug: e => console.warn(e),
-  warn: e => console.warn(e),
-  child: e => console.warn(e),
-  http: e => console.warn(e),
-  trace: e => console.warn(e)
+  error: e => jest.fn(),
+  info: e => jest.fn(),
+  debug: e => jest.fn(),
+  warn: e => jest.fn(),
+  child: e => jest.fn(),
+  http: e => jest.fn(),
+  trace: e => jest.fn()
 };
 
 beforeAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,11 +1266,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/http-errors@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.verdaccio.org/@types%2fhttp-errors/-/http-errors-1.6.1.tgz#367744a6c04b833383f497f647cc3690b0cd4055"
-  integrity sha512-s+RHKSGc3r0m3YEE2UXomJYrpQaY9cDmNDLU2XvG1/LAZsQ7y8emYkTLfcw/ByDtcsTyRQKwr76Bj4PkN2hfWg==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.verdaccio.org/@types%2fistanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1419,10 +1414,10 @@
     babel-plugin-emotion "10.0.9"
     babel-plugin-flow-runtime "0.19.0"
 
-"@verdaccio/commons-api@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fcommons-api/-/commons-api-0.1.0.tgz#6d36820038b64ee34026a2dcf15a15d6c3623edf"
-  integrity sha512-qWIaXL9fzUabiAKRp1idROBeCn3GUwfMjwpOd3wDHwP1LQJZh0CDifIP+p0DROx2mR/fAteu0SIRRP5hV41Ryg==
+"@verdaccio/commons-api@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fcommons-api/-/commons-api-0.1.1.tgz#2248e98fb43b258da026e761140141e3f2fd213b"
+  integrity sha512-n7JdKfac9TV5CubXP3ZeH5Ci8Gj/Q+gPfYF5pwm9MRH5VYs3oNWFtjGsOVZEKDTeKGelnf/Ht6iuAE9LVWntiQ==
   dependencies:
     http-errors "1.7.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,20 +1303,20 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/lodash@^4.14.135":
+"@types/lodash@4.14.135":
   version "4.14.135"
   resolved "https://registry.verdaccio.org/@types%2flodash/-/lodash-4.14.135.tgz#d2607c35dd68f70c2b35ba020c667493dedd8447"
   integrity sha512-Ed+tSZ9qM1oYpi5kzdsBuOzcAIn1wDW+e8TFJ50IMJMlSopGdJgKAbhHzN6h1E1OfjlGOr2JepzEWtg9NIfoNg==
 
-"@types/minimatch@^3.0.3":
+"@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.verdaccio.org/@types%2fminimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@12.0.10":
-  version "12.0.10"
-  resolved "https://registry.verdaccio.org/@types%2fnode/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
-  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+"@types/node@12.0.12":
+  version "12.0.12"
+  resolved "https://registry.verdaccio.org/@types%2fnode/-/node-12.0.12.tgz#cc791b402360db1eaf7176479072f91ee6c6c7ca"
+  integrity sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1419,6 +1419,13 @@
     babel-plugin-emotion "10.0.9"
     babel-plugin-flow-runtime "0.19.0"
 
+"@verdaccio/commons-api@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fcommons-api/-/commons-api-0.1.0.tgz#6d36820038b64ee34026a2dcf15a15d6c3623edf"
+  integrity sha512-qWIaXL9fzUabiAKRp1idROBeCn3GUwfMjwpOd3wDHwP1LQJZh0CDifIP+p0DROx2mR/fAteu0SIRRP5hV41Ryg==
+  dependencies:
+    http-errors "1.7.3"
+
 "@verdaccio/eslint-config@0.0.1":
   version "0.0.1"
   resolved "https://registry.verdaccio.org/@verdaccio%2feslint-config/-/eslint-config-0.0.1.tgz#27a7564b2f0d665b4af85a8cbab999725ce69a40"
@@ -1447,10 +1454,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2fstreams/-/streams-2.0.0.tgz#27f51d0cb19d5e49248860942092646e9a357967"
   integrity sha512-QW1LsYir3wNnqhSznbJlt0iqkcgve0LpXI8RkoTTBPrq3M6ei3Ys4iw+JQKFve3gmYw9O+w8lBiOLc1qvvsoVQ==
 
-"@verdaccio/types@5.0.0-beta.4":
-  version "5.0.0-beta.4"
-  resolved "https://registry.verdaccio.org/@verdaccio%2ftypes/-/types-5.0.0-beta.4.tgz#433a36bef5b3bbd31711c48071989ac35dc83e54"
-  integrity sha512-aPrCUrFMXo/ikgT/9YEAr5EDlH2gFJGfdrUra2ipQxV3SbNrRN95KxwwSDS+W+YKG0+rAIQKIxnx8hf6gEtePQ==
+"@verdaccio/types@5.2.2":
+  version "5.2.2"
+  resolved "https://registry.verdaccio.org/@verdaccio%2ftypes/-/types-5.2.2.tgz#ecea86c864b905314e29c88e5f93aebcf116c5ff"
+  integrity sha512-5NbSsCcwCt5ZrA6+vXqUXFM2tAXkS++dju5XSh4TGM+ISon/FS/oUQtE7zmhlaftCt2z2LRhg0/b3wV8QUxSGQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

*  There is a related issue? no
*  Unit or Functional tests are included in the PR (not need it)

**Description:**

It add useful debug info in log files, really handy when some users have write permission issues at Docker, eg:

```
debug--- [local-storage/_sync]: init sync database
 debug--- [local-storage/_sync]: folder /Users/user/projects/verdaccio.master.git/test/unit/partials/mock-store created succeed
 debug--- [local-storage/_sync/writeFileSync]: sync write succeed
 debug--- [local-storage/_sync]: init sync database
 debug--- [local-storage/_sync]: folder /Users/user/projects/verdaccio.master.git/test/unit/partials/mock-store created succeed
 debug--- [local-storage/_sync/writeFileSync]: sync write succeed
 warn --- Plugin successfully loaded: verdaccio-auth-memory
 warn --- http address - http://localhost:55530/ - verdaccio/4.1.0
 info <-- 127.0.0.1 requested 'GET /-/_debug'
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/_debug', bytes: 0/331
 info <-- 127.0.0.1 requested 'PUT /-/user/org.couchdb.user:test/-rev/undefined'
 trace--- api middleware using legacy auth token
 trace--- authenticating test
 info --- [VerdaccioMemory] authentication succeeded for test
 trace--- authentication for user test was successfully. Groups: [ 'test' ]
(node:70482) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
 trace--- authenticating test
 info --- [VerdaccioMemory] authentication succeeded for test
 trace--- authentication for user test was successfully. Groups: [ 'test' ]
 http <-- 201, user: test(127.0.0.1), req: 'PUT /-/user/org.couchdb.user:test/-rev/undefined', bytes: 149/85
 info <-- 127.0.0.1 requested 'GET /vue'
 trace--- allow access for vue
 debug--- [VerdaccioMemory] user: undefined has been granted access
 trace--- allowed access for vue
 trace--- [local-storage/getPackageStorage]: storage selected: ./mock-store
 trace--- [local-storage/getPackageStorage]: storage path: /Users/user/projects/verdaccio.master.git/test/unit/partials/mock-store/vue
 debug--- [local-storage/readPackage] read a package: vue
 trace--- [local-storage/_readStorageFile] read a file: /Users/user/projects/verdaccio.master.git/test/unit/partials/mock-store/vue/package.json
 trace--- [local-storage/_readStorageFile] read file succeed: /Users/user/projects/verdaccio.master.git/test/unit/partials/mock-store/vue/package.json

```
