### PR TITLE
refactor: removes use of fs.exists and updates mocks

### DIFF
--- a/src/local-database.ts
+++ b/src/local-database.ts
@@ -307,11 +307,17 @@ class LocalDatabase implements IPluginStorage<{}> {
     };
 
     const sinopiadbPath: string = dbGenPath(DEPRECATED_DB_NAME);
-    if (fs.existsSync(sinopiadbPath)) {
+    try {
+      fs.accessSync(sinopiadbPath, fs.constants.F_OK);
       return sinopiadbPath;
+    } catch (err) {
+      if(err.code === noSuchFile) {
+        return dbGenPath(DB_NAME);
+      }
+
+      throw err
     }
 
-    return dbGenPath(DB_NAME);
   }
 
   /**

--- a/src/local-fs.ts
+++ b/src/local-fs.ts
@@ -10,7 +10,7 @@ import { unlockFile, readFile } from '@verdaccio/file-locking';
 import { Callback, Logger, Package, ILocalPackageManager, IUploadTarball } from '@verdaccio/types';
 import { getCode, getInternalError, getNotFound, VerdaccioError } from '@verdaccio/commons-api/lib';
 
-export const fileExist = 'EEXIST';
+export const fileExist = 'EEXISTS';
 export const noSuchFile = 'ENOENT';
 export const resourceNotAvailable = 'EAGAIN';
 export const pkgFileName = 'package.json';
@@ -289,7 +289,8 @@ export default class LocalFS implements ILocalFSPackageManager {
 
     fs.open(name, 'wx', err => {
       if (err) {
-        if (err.code === fileExist) {
+        // native EEXIST used here to check exception on fs.open
+        if (err.code === 'EEXIST') {
           this.logger.trace({ name }, '[local-storage/_createFile] file cannot be created, it already exists: @{name}');
           return callback(fSError(fileExist));
         }

--- a/tests/local-database.test.ts
+++ b/tests/local-database.test.ts
@@ -167,7 +167,10 @@ describe('Local Database', () => {
       const nonScopedPackages = ['@pkg1/test'];
       jest.doMock('fs', () => {
         return {
-          existsSync: () => true,
+          accessSync: () => {},
+          constants: {
+            F_OK: 0
+          },
           stat: (storePath, cb) =>
             cb(null, {
               mtime: new Date()
@@ -189,7 +192,10 @@ describe('Local Database', () => {
       const nonScopedPackages = ['pkg1', 'pkg2'];
       jest.doMock('fs', () => {
         return {
-          existsSync: () => true,
+          accessSync: () => {},
+          constants: {
+            F_OK: 0
+          },
           stat: (storePath, cb) =>
             cb(null, {
               mtime: new Date()
@@ -216,7 +222,10 @@ describe('Local Database', () => {
     test('should fails on read the storage', done => {
       jest.doMock('fs', () => {
         return {
-          existsSync: () => true,
+          accessSync: () => {},
+          constants: {
+            F_OK: 0
+          },
           stat: (storePath, cb) =>
             cb(null, {
               mtime: new Date()


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** Refactor

The following has been addressed in the PR:

*  There is a related issue? #171
*  Unit tests for the changed files have been verified and mocks updated as needed in the PR

**Description:**
Since fs.exists is deprecated, this pull request removes it from product source.
<!-- Resolves #171 -->
